### PR TITLE
Fix codec dependency in the browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,5 @@
 module.exports = function (file, suffix, _codec) {
-  var codec = _codec || require('./codec')
+  var codec = _codec || require('./codec/json')
   return {
     set: function (v, cb) {
       console.log('set', file, v)


### PR DESCRIPTION
This commit resolves an issue where `require('./codec')` ambiguously references a directory rather than a JavaScript file.